### PR TITLE
About box fix

### DIFF
--- a/src/replicatorg/app/ui/MainWindow.java
+++ b/src/replicatorg/app/ui/MainWindow.java
@@ -934,7 +934,7 @@ public class MainWindow extends JFrame implements MRJAboutHandler, MRJQuitHandle
 		// macosx already has its own about menu
 		menu.addSeparator();
 		JMenuItem aboutitem = new JMenuItem("About ReplicatorG");
-		item.addActionListener(new ActionListener() {
+		aboutitem.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				handleAbout();
 			}
@@ -2325,8 +2325,7 @@ public class MainWindow extends JFrame implements MRJAboutHandler, MRJQuitHandle
 						machine.connect();
 					} catch (SerialException e) {
 						Base.logger.log(Level.WARNING,
-								"Could not use most recently selected serial port ("+lastPort+").",
-								e);
+								"Could not use most recently selected serial port ("+lastPort+").");
 						return;
 					}
 				}


### PR DESCRIPTION
This is a small fix to:
- make the about box work for Windows computers. There had been a small typo in the code
- disable the huge exception in the console output when the makerbot is not connected to the computer. A simple warning with the used port is considered sufficient (by me).
