### PR TITLE
Added STL as supported file typ on OS X

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -157,6 +157,10 @@
                     extensions="gcode" 
                     iconFile="${dist.dir}/replicatorg.icns"
                     role="Editor"/>
+      <documenttype name="CNC STL document" 
+                    extensions="stl" 
+                    iconFile="${dist.dir}/replicatorg.icns"
+                    role="Editor"/>
       <resourcefileset dir="${lib.dir}" includes="*.gif"/>
       <resourcefileset dir="${lib.dir}" includes="*.jpg"/>
       <javaproperty name="replicatorg.app-resources" value="$APP_PACKAGE/Contents/Resources"/>


### PR DESCRIPTION
I don't know if this will effect other OSs however. But it makes it so you can double-click open STLs with RepG or drag to RepG to open.
