### PR TITLE
5axis

### DIFF
--- a/src/replicatorg/drivers/reprap/SimpleRepRap5DDriver.java
+++ b/src/replicatorg/drivers/reprap/SimpleRepRap5DDriver.java
@@ -46,6 +46,7 @@ import replicatorg.drivers.SerialDriver;
 
 import replicatorg.machine.model.Axis;
 import replicatorg.machine.model.ToolModel;
+import replicatorg.util.Point5d;
 
 public class SimpleRepRap5DDriver extends SerialDriver {
 	/**
@@ -321,22 +322,22 @@ public class SimpleRepRap5DDriver extends SerialDriver {
 	 * @throws RetryException 
 	 **************************************************************************/
 
-	public void queuePoint(Point3d p) throws RetryException {
+	public void queuePoint(Point5d p) throws RetryException {
 		String cmd = "G1 F" + df.format(getCurrentFeedrate());
 		
 		sendCommand(cmd);
 
-		cmd = "G1 X" + df.format(p.x) + " Y" + df.format(p.y) + " Z"
-				+ df.format(p.z) + " F" + df.format(getCurrentFeedrate());
+		cmd = "G1 X" + df.format(p.x()) + " Y" + df.format(p.y()) + " Z"
+				+ df.format(p.z()) + " F" + df.format(getCurrentFeedrate());
 
 		sendCommand(cmd);
 
 		super.queuePoint(p);
 	}
 
-	public void setCurrentPosition(Point3d p) throws RetryException {
-		sendCommand("G92 X" + df.format(p.x) + " Y" + df.format(p.y) + " Z"
-				+ df.format(p.z));
+	public void setCurrentPosition(Point5d p) throws RetryException {
+		sendCommand("G92 X" + df.format(p.x()) + " Y" + df.format(p.y()) + " Z"
+				+ df.format(p.z()));
 
 		super.setCurrentPosition(p);
 	}
@@ -562,8 +563,8 @@ public class SimpleRepRap5DDriver extends SerialDriver {
 		initialize();
 	}
 
-	protected Point3d reconcilePosition() {
-		return new Point3d(0,0,0);
+	protected Point5d reconcilePosition() {
+		return new Point5d();
 	}
 }
 


### PR DESCRIPTION
This is the 5 axis support feature branch for ReplicatorG. It should work well with Cupcakes and other non-5 axis machines since the 5 axis stuff is only enabled when using the Makerbot4G driver.
Nevertheless, most Point3d's were changes to Point5d, so this should be put into testing as soon as possible and hopefully released so it's mature before 5 axis becomes common.

Basically, test with this branch first and merge when it feels right.
