### PR TITLE
Feature: Set debug level from CLI

### DIFF
--- a/machines.xml.dist
+++ b/machines.xml.dist
@@ -342,7 +342,7 @@ M108 S0
                         <axis id="z" length="210" maxfeedrate="150" scale="160" endstops="min"/> <!-- quarter-step driver -->
                 </geometry>
                 <tools>
-                        <tool name="Stepper-based pinch extruder" type="extruder" material="abs" motor="true" floodcoolant="false" mistcoolant="false" fan="true" valve="false" collet="false" heater="true" heatedplatform="true" motor_steps="200" />
+                        <tool name="Stepper-based pinch extruder" type="extruder" material="abs" motor="true" floodcoolant="false" mistcoolant="false" fan="true" valve="false" collet="false" heater="true" heatedplatform="true" motor_steps="200" default_rpm="1000" />
                 </tools>
                 <clamps></clamps>
                 <firmware url="http://firmware.ultimaker.com/latest" autoupgrade="false"></firmware>

--- a/src/replicatorg/app/Base.java
+++ b/src/replicatorg/app/Base.java
@@ -231,10 +231,42 @@ public class Base {
 							+ "Please visit java.com to upgrade.", null);
 		}
 
-		// grab any opened file from the command line
 
-		if (args.length == 1) {
-			Base.openedAtStartup = args[0];
+		// parse command line input
+		for (int i=0;i<args.length;i++) {
+			// grab any opened file from the command line
+			if(args[i].endsWith(".gcode") || args[i].endsWith(".stl") || args[i].endsWith(".dae")) {
+				Base.openedAtStartup = args[i];
+			}
+			
+			// Allow for [--debug] [DEBUGLEVEL]
+			if(args[i].equals("--debug")) {
+				int debugLevelArg = 2;
+				if((i+1) < args.length) {
+					try {
+						debugLevelArg = Integer.parseInt(args[i+1]);
+					} catch (NumberFormatException e) {};
+				}
+				if(debugLevelArg == 0) {
+					logger.setLevel(Level.INFO);
+					logger.info("Debug level is 'INFO'");
+				} else if(debugLevelArg == 1) {
+					logger.setLevel(Level.FINE);
+					logger.info("Debug level is 'FINE'");
+				} else if(debugLevelArg == 2) {
+					logger.setLevel(Level.FINER);
+					logger.info("Debug level is 'FINER'");
+				} else if(debugLevelArg == 3) {
+					logger.setLevel(Level.FINEST);
+					logger.info("Debug level is 'FINEST'");
+				} else if(debugLevelArg >= 4) {
+					logger.setLevel(Level.ALL);
+					logger.info("Debug level is 'ALL'");
+				}
+			} else if(args[i].startsWith("-")){
+				System.out.println("Usage: ./replicatorg [[--debug] [DEBUGLEVEL]] [filename.stl]");
+				System.exit(1);
+			}
 		}
 		
 		// Warn about read-only directories

--- a/src/replicatorg/app/ui/controlpanel/ExtruderPanel.java
+++ b/src/replicatorg/app/ui/controlpanel/ExtruderPanel.java
@@ -162,7 +162,7 @@ public class ExtruderPanel extends JPanel implements FocusListener, ActionListen
 				field.setName("motor-speed-pwm");
 				field.addFocusListener(this);
 				field.setActionCommand("handleTextfield");
-				field.setText(Double.toString(t.getMotorSpeedPWM()));
+				field.setText(Integer.toString(t.getMotorSpeedPWM()));
 				field.addActionListener(this);
 
 				add(label);

--- a/src/replicatorg/app/ui/controlpanel/ExtruderPanel.java
+++ b/src/replicatorg/app/ui/controlpanel/ExtruderPanel.java
@@ -162,6 +162,7 @@ public class ExtruderPanel extends JPanel implements FocusListener, ActionListen
 				field.setName("motor-speed-pwm");
 				field.addFocusListener(this);
 				field.setActionCommand("handleTextfield");
+				field.setText(Double.toString(t.getMotorSpeedPWM()));
 				field.addActionListener(this);
 
 				add(label);
@@ -184,6 +185,7 @@ public class ExtruderPanel extends JPanel implements FocusListener, ActionListen
 				field.setName("motor-speed");
 				field.addFocusListener(this);
 				field.setActionCommand("handleTextfield");
+				field.setText(Double.toString(t.getMotorSpeedRPM()));
 				field.addActionListener(this);
 
 				add(label);

--- a/src/replicatorg/drivers/reprap/RepRap5DDriver.java
+++ b/src/replicatorg/drivers/reprap/RepRap5DDriver.java
@@ -362,7 +362,7 @@ public class RepRap5DDriver extends SerialDriver {
 							// TODO: check if this was supposed to happen, otherwise report unexpected reset! 
 							setInitialized(true);
 							Base.logger.info(line);
-							lineNumber = -1;
+							lineNumber = 0;
 						} else if (line.startsWith("Extruder Fail")) {
 							setError("Extruder failed:  cannot extrude as this rate.");
 						} else if (line.startsWith("Resend:")||line.startsWith("rs ")) {

--- a/src/replicatorg/machine/model/ToolModel.java
+++ b/src/replicatorg/machine/model/ToolModel.java
@@ -195,7 +195,22 @@ public class ToolModel
 				}
 			} catch (Exception e) {} // ignore parse errors.
 
-		}
+			n = XML.getAttributeValue(xml, "default_rpm");
+			try{
+				if (Double.parseDouble(n) > 0)
+				{
+					motorSpeedRPM = Double.parseDouble(n);
+				}
+			} catch (Exception e) {} // ignore parse errors.
+
+			n = XML.getAttributeValue(xml, "default_pwm");
+			try{
+				if (Integer.parseInt(n) > 0)
+				{
+					motorSpeedPWM = Integer.parseInt(n);
+				}
+			} catch (Exception e) {} // ignore parse errors.
+}
 
 		n = XML.getAttributeValue(xml, "spindle");
 		if (isTrueOrOne(n))


### PR DESCRIPTION
You could cherry-pick 7995ea6 if you like.

The debug level can now be set via the commandline ([--debug [level]]) + small CLI help.

Since there's now more differentiation in log levels (many info stuff is now "fine") it's now valuable to differentiate debuggers from everyday users.

Would checking a .replicatorg/debug.txt file be appropriate too? This would not require you type it every time? Also, perhaps the ant target could be changed?
