### PR TITLE
mac dist builds fail with addition of new SF versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/classes
 *.class
 #.
 *~
+RepG.log

--- a/build/macosx/dist/mkdmg.sh
+++ b/build/macosx/dist/mkdmg.sh
@@ -14,7 +14,7 @@ TEMP="TEMPORARY"
 
 cd $BASE
 
-hdiutil create -megabytes 50 $DEST$TEMP.dmg -layout NONE
+hdiutil create -megabytes 100 $DEST$TEMP.dmg -layout NONE
 MY_DISK=`hdid -nomount $DEST$TEMP.dmg`
 echo My Dist $MY_DISK
 newfs_hfs -v $VOLUME $MY_DISK


### PR DESCRIPTION
with the addition of the new skeinforge versions, the previous 50 MB temporary disk image created was running out of room.  the size needs to be bumped, and is now at 100 MB.  the change is to build/macosx/dist/mkdmg.sh

"ant run" produces a RepG.log file that has been added to .gitinore. 
