### PR TITLE
remove wipe commands from cupcake configs

### DIFF
--- a/skein_engines/skeinforge-0006/prefs/cupcake-mk4-automated-platform-abs/gcode_scripts/end.txt
+++ b/skein_engines/skeinforge-0006/prefs/cupcake-mk4-automated-platform-abs/gcode_scripts/end.txt
@@ -11,11 +11,6 @@ M104 S225 T0 (set extruder temperature)
 M109 S130 T0 (set heated-build-platform temperature)
 G04 P7000 (wait t/1000 seconds)
 M107 (conveyor off)
-(start wipe)
-G1 X-53 Y-15.5 Z6.5 F2500.0
-G1 X-53 Y0 Z6.5 F2500.0
-G1 X-53 Y15.5 Z6.5 F2500.0
-(end wipe)
 G1 X0 Y0 F3300.0 (move nozzle to center)
 G1 X0 Y0 Z0 F3300.0 (move nozzle to origin)
 M104 S0 T0 (set extruder temperature)

--- a/skein_engines/skeinforge-0006/prefs/cupcake-mk4-automated-platform-abs/gcode_scripts/start.txt
+++ b/skein_engines/skeinforge-0006/prefs/cupcake-mk4-automated-platform-abs/gcode_scripts/start.txt
@@ -11,11 +11,6 @@ G04 P85000 (Wait t/1000 seconds)
 M101 (Extruder on, forward)
 G04 P6500 (Wait t/1000 seconds)
 M103 (Extruder off)
-(start wipe)
-G1 X-54 Y-30 Z6 F2000.0
-G1 X-54 Y-12.5 Z6 F2000.0
-G1 X-54 Y4 Z6 F2000.0
-(end wipe)
 G1 X-30 Y30 Z6 F3300.0 (move to initial position)
 G1 Z0 F3300.0 (Go back down)
 M101 (start extruder, fwd)

--- a/skein_engines/skeinforge-0006/prefs/cupcake-mk5-automated-platform-abs/gcode_scripts/end.txt
+++ b/skein_engines/skeinforge-0006/prefs/cupcake-mk5-automated-platform-abs/gcode_scripts/end.txt
@@ -11,11 +11,6 @@ M104 S225 T0 (set extruder temperature)
 M109 S130 T0 (set heated-build-platform temperature)
 G04 P7000 (wait t/1000 seconds)
 M107 (conveyor off)
-(start wipe)
-G1 X-53 Y-15.5 Z6.5 F2500.0
-G1 X-53 Y0 Z6.5 F2500.0
-G1 X-53 Y15.5 Z6.5 F2500.0
-(end wipe)
 G1 X0 Y0 F3300.0 (move nozzle to center)
 G1 X0 Y0 Z0 F3300.0 (move nozzle to origin)
 M104 S0 T0 (set extruder temperature)

--- a/skein_engines/skeinforge-0006/prefs/cupcake-mk5-automated-platform-abs/gcode_scripts/start.txt
+++ b/skein_engines/skeinforge-0006/prefs/cupcake-mk5-automated-platform-abs/gcode_scripts/start.txt
@@ -11,11 +11,6 @@ G04 P85000 (Wait t/1000 seconds)
 M101 (Extruder on, forward)
 G04 P6500 (Wait t/1000 seconds)
 M103 (Extruder off)
-(start wipe)
-G1 X-54 Y-30 Z6 F2000.0
-G1 X-54 Y-12.5 Z6 F2000.0
-G1 X-54 Y4 Z6 F2000.0
-(end wipe)
 G1 X-30 Y30 Z6 F3300.0 (move to initial position)
 G1 Z0 F3300.0 (Go back down)
 M101 (start extruder, fwd)


### PR DESCRIPTION
The wipe commands on a cupcake with ABP result in the head crashing into the ABP and tearing up the plastic.    For now, I'm just removing them.
