### PR TITLE
Adding the setPlatformTemperature to the RepRap5DDriver

### DIFF
--- a/src/replicatorg/drivers/reprap/RepRap5DDriver.java
+++ b/src/replicatorg/drivers/reprap/RepRap5DDriver.java
@@ -971,6 +971,12 @@ public class RepRap5DDriver extends SerialDriver implements SerialFifoEventListe
 	public double getPlatformTemperature(){
 		return machine.currentTool().getPlatformCurrentTemperature();
 	}
+
+	public void setPlatformTemperature(double temperature) throws RetryException {
+		sendCommand(_getToolCode() + "M140 S" + df.format(temperature));
+		
+		super.setPlatformTemperature(temperature);
+	}
 	/***************************************************************************
 	 * Flood Coolant interface functions
 	 **************************************************************************/


### PR DESCRIPTION
Hi,
I noticed that I was not able to preheat my heatbed with the control panel because ReplicatorG (or the RepRap5DDriver) did not know the GCode to it.
Thanks a lot for pulling my first pull request :)

~lImbus
