### PR TITLE
* Added excess calculation to ensure that we don't lose steps to rounding

### DIFF
--- a/src/replicatorg/machine/model/MachineModel.java
+++ b/src/replicatorg/machine/model/MachineModel.java
@@ -324,6 +324,21 @@ public class MachineModel
 	}
 
 	/*************************************
+	*  Convert millimeters to machine steps,
+	*  factoring in previous rounding error
+	*  and providing carryover error
+	*************************************/
+
+	public Point5d mmToSteps(Point5d mm, Point5d excess)
+	{
+		Point5d temp = new Point5d();
+		temp.mul(mm,stepsPerMM);
+		temp.add(excess);
+		temp.round(excess); // integer step counts please
+		return temp;
+	}
+
+	/*************************************
 	* Drive interface functions
 	*************************************/
 	public void enableDrives()

--- a/src/replicatorg/util/Point5d.java
+++ b/src/replicatorg/util/Point5d.java
@@ -53,6 +53,12 @@ public class Point5d {
 		}
 	}
 
+	public void sub(Point5d p1) {
+		for (int idx = 0; idx < DIMENSIONS; idx++) {
+			values[idx] -= p1.values[idx];
+		}
+	}
+
 	public void sub(Point5d p1, Point5d p2) {
 		for (int idx = 0; idx < DIMENSIONS; idx++) {
 			values[idx] = p1.values[idx] - p2.values[idx];
@@ -92,7 +98,20 @@ public class Point5d {
 			values[idx] = Math.round(values[idx]);
 		}
 	}
-		
+
+	/**
+	 * Round each element of the point to the nearest integer
+	 * (using Math.round), storing the excess in the provided
+	 * point object.
+	 */
+	public void round(Point5d excess) {
+		for (int idx = 0; idx < DIMENSIONS; idx++) {
+			double rounded = Math.round(values[idx]);
+			excess.values[idx] = values[idx] - rounded;
+			values[idx] = rounded;
+		}
+	}
+
 	public void absolute() {
 		for (int idx = 0; idx < DIMENSIONS; idx++) {
 			values[idx] = Math.abs(values[idx]);


### PR DESCRIPTION
This is the code that ensures that the mm to step rounding doesn't cause us to lose steps. The remainder of the rounding conversion is maintained and added as an error term to subsequent moves. This solves the problem where pathologically small steps were causing prints to skip steps to the extruder.
