### PR TITLE
Fix loss of selected tool.

### DIFF
--- a/src/replicatorg/app/GCodeParser.java
+++ b/src/replicatorg/app/GCodeParser.java
@@ -368,6 +368,7 @@ public class GCodeParser {
 		// you may wish to avoid using M6.
 		if (gcode.hasCode('T') && driver instanceof MultiTool && ((MultiTool)driver).supportsSimultaneousTools()) {
 			commands.add(new replicatorg.drivers.commands.SelectTool((int) gcode.getCodeValue('T')));
+			tool = (int) gcode.getCodeValue('T');
 		}
 		switch ((int) gcode.getCodeValue('M')) {
 		case 0:


### PR DESCRIPTION
The tool selection, based on Gx Tx commands, was not setting the tool variable, and so Ex 5D commands were not getting converted to a tool. This worked in 24, but broke with all of the rearranging in 25.

Thank you,
  -Rob
