### PR TITLE
Get the preference using the same name as the preferences UI

### DIFF
--- a/src/replicatorg/machine/Machine.java
+++ b/src/replicatorg/machine/Machine.java
@@ -245,7 +245,7 @@ public class Machine implements MachineInterface {
 		// TODO: Is this correct?
 		estimator.setMachine(machineThread.getModel());
 		
-		boolean safetyChecks = Base.preferences.getBoolean("build.runSafetyChecks", true);
+		boolean safetyChecks = Base.preferences.getBoolean("build.safetyChecks", true);
 		
 		int nToolheads = machineThread.getModel().getTools().size();
 		Point5d maxRates = machineThread.getModel().getMaximumFeedrates();


### PR DESCRIPTION
Noticed this bug in lighthouse and thought it sounded simple.

Grep through the source showed that different property names were being used for read/write of the pref.

Changed the read to use the same name as the write (so if anyone has already saved the pref it will now work).
