### PR TITLE
Hooks to run scripts upon build start, stop, and complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ ReplicatorG.app
 .classpath
 .project
 *.diff
+.DS_Store


### PR DESCRIPTION
These allow additional automation to be added when builds are started, stopped and completed. If the start.sh, stop.sh, or complete.sh are available in the scripts directory, they will be run at the appropriate times. If they are not available, it will fail silently. The scripts are passed in the name of the file being printed as well as some times (start time for the start script, time elapsed for the stop and complete script). Stdout and stderr from the scripts are displayed in the ReplicatorG console.

I use this to automate recording, YouTube uploading, and tweeting of everything made on my Thing-O-Matic (see @YelperBot on twitter, see https://github.com/johnboiles/ReplicatorG/tree/youtube_twitter_scripts for the scripts).

I can also think of other uses for this. Perhaps scripts are written to notify a web service that a communal 3d printer is free or in use. Or perhaps a picture is taken of every completed 3d object.
