### PR TITLE
Fix for ToM 5D Dualstrusion

### DIFF
--- a/src/replicatorg/drivers/gen3/Makerbot4GDriver.java
+++ b/src/replicatorg/drivers/gen3/Makerbot4GDriver.java
@@ -173,7 +173,11 @@ public class Makerbot4GDriver extends Sanguino3GDriver {
 	 * Overridden to not talk to the DC motor driver. This driver is reused for the stepper motor fan
 	 */
 	public void setMotorRPM(double rpm, int toolhead) throws RetryException {
-		machine.getTool(toolhead).setMotorSpeedRPM(rpm);
+	  if (toolhead == -1) {
+		  machine.currentTool().setMotorSpeedRPM(rpm);
+	  } else {
+	    machine.getTool(toolhead).setMotorSpeedRPM(rpm);
+	  }
 	}
 	
 	


### PR DESCRIPTION
When using the makerbot4g driver/5D dimension with dual extruders on a ToM, you get the following error: 

Cannot get nonexistent tool (#-1.

This fixes it by basically doing the same thing the Mightyboard driver does, lets you set the tool by sending an M108 T0 command.
