### PR TITLE
Fix for skeinforge comb crash on thin structures.

### DIFF
--- a/skein_engines/skeinforge-47/skeinforge_application/skeinforge_plugins/craft_plugins/comb.py
+++ b/skein_engines/skeinforge-47/skeinforge_application/skeinforge_plugins/craft_plugins/comb.py
@@ -146,7 +146,7 @@ class BoundarySegment:
 		nextBegin = nextBoundarySegment.segment[0]
 		end = getJumpPointIfInside(self.boundary, nextBegin, perimeterWidth, runningJumpSpace)
 		if end == None:
-			end = self.boundary.segment[1]
+			end = self.segment[1]
 		nextBegin = getJumpPointIfInside(nextBoundarySegment.boundary, end, perimeterWidth, runningJumpSpace)
 		if nextBegin != None:
 			nextBoundarySegment.segment[0] = nextBegin


### PR DESCRIPTION
When skeining extremely thin structures comb.py has the potential to crash.  Removing .boundary allows the code to function correctly.

Credit to Daid for finding this: http://groups.google.com/group/ultimaker/msg/576f52b1407e901a
