### PR TITLE
Fix support for unofficial firmware update servers that do not include type tags in their HTTP responses.

### DIFF
--- a/src/replicatorg/uploader/FirmwareRetriever.java
+++ b/src/replicatorg/uploader/FirmwareRetriever.java
@@ -12,6 +12,10 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.util.logging.Level;
+import java.io.FileWriter;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -50,7 +54,7 @@ class FirmwareRetriever {
 	 * @return an UpdateStatus reflecting the result of the update check.
 	 */
 	UpdateStatus checkForUpdates() {
-		//System.err.println("PATH : "+ firmwareSourceURL.getPath());
+		Base.logger.fine("Firmware Source URL : "+ firmwareSourceURL);
 		UpdateStatus status;
 		synchronized(getClass()) {
 			status = updateURL(firmwareSourceURL,firmwareXml,true);
@@ -104,20 +108,31 @@ class FirmwareRetriever {
 			}
 
 			// Pull down the file.  The content should be an input stream.
-			InputStream content = (InputStream)urlConnection.getContent();
-			FileOutputStream out = new FileOutputStream(file);
+                        //Get content doesn't work if the "Content-Type: text/plain" header is not present in the HTTP header.
+                        //Some servers don't know how exactly to treat .hex files and so it's safe to assume that this will not be around in most packet responses.
+			//Therefore, we must use the raw input stream piped to a buffered stream for getting our data
+
+			BufferedReader packetData = new BufferedReader( new InputStreamReader( urlConnection.getInputStream() ) );
+			FileWriter fileOutput = new FileWriter( file.getAbsoluteFile() );
+			BufferedWriter fileBufferedOutput = new BufferedWriter(fileOutput);
+
 			// Welcome to 1994!  Seriously, there's no standard util for this?  Lame.
-			final int BUF_SIZE=2048;
-			byte buf[] = new byte[BUF_SIZE];
+
 			int bytesWritten = 0;
+			final int BUF_SIZE=2048;
+			char buf[] = new char[BUF_SIZE];
+			
 			while (true) {
-				int count = content.read(buf);
+				int count = packetData.read(buf,0,BUF_SIZE);
 				if (count == -1) break;
 				bytesWritten = bytesWritten + count;
-				out.write(buf, 0, count);
+				fileBufferedOutput.write(buf, 0, count);
 			}
-			out.close();
-			content.close();
+			packetData.close();
+
+			fileBufferedOutput.close();
+			fileOutput.close();
+
 			Base.logger.info(Integer.toString(bytesWritten) + " bytes written to "+file.getCanonicalPath());
 			return UpdateStatus.NEW_UPDATES;
 		} catch (MalformedURLException e) {
@@ -150,6 +165,7 @@ class FirmwareRetriever {
 			URL url;
 			try {
 				url = new URL(firmwareSourceURL,path);
+				Base.logger.fine("Checking remote file: "+ url);
 				File file = Base.getUserFile(path);
 				updateURL(url,file);
 			} catch (MalformedURLException e) {
@@ -158,6 +174,7 @@ class FirmwareRetriever {
 			String eeprom = new FirmwareVersion(n).getEepromPath();
 			if (eeprom != null) try {
 				url = new URL(firmwareSourceURL,eeprom);
+				Base.logger.fine("Checking remote file: "+ url);
 				File file = Base.getUserFile(path);
 				updateURL(url,file);
 			} catch (MalformedURLException e) {


### PR DESCRIPTION
Hey all, how's it going? Here's a solution to a ghost bug I've been dealing with all day now.

For some servers, the HTTP 200 OK return packets (containing the requested firmware file data) are not headed with a "Content-Type: text/plain" and therefore silently fail to be saved to disk. This silent failure can prove very frustrating for users who want to use un-official firmware update servers by entering their URL into RepG's preference pane and are unsure why ReplicatorG appears to successfully fetch and parse the firmware.xml, but doesn't actually end up saving the new files. This commit fixes the bug by dealing with the packet data in its (almost) raw form, thus rendering the type tag unnecessary.

For some reason, this error doesn't show up on any log file (ReplicatorG or otherwise) in any log level, but was diagnosed through a lengthy packet-by-packet investigation with Wireshark. Here's the annotated screen capture and side-by-side comparison of the two server responses: http://goo.gl/kuUt4

Happy Hacking!
-Winter Guerra
