### PR TITLE
Update src/replicatorg/app/ui/modeling/Tool.java

### DIFF
--- a/src/replicatorg/app/ui/modeling/Tool.java
+++ b/src/replicatorg/app/ui/modeling/Tool.java
@@ -86,7 +86,7 @@ public abstract class Tool implements MouseMotionListener, MouseListener, MouseW
 		DragMode mode = DragMode.ROTATE_VIEW; 
 		if (Base.isMacOS()) {
 			if (button == MouseEvent.BUTTON1 && !e.isShiftDown()) { mode = DragMode.ROTATE_VIEW; }
-			else if (button == MouseEvent.BUTTON1 && e.isShiftDown()) { mode = DragMode.ROTATE_VIEW; }
+			else if (button == MouseEvent.BUTTON1 && e.isShiftDown()) { mode = DragMode.TRANSLATE_VIEW; }
 		} else {
 			if (button == MouseEvent.BUTTON1) { mode = DragMode.ROTATE_VIEW; }
 			else if (button == MouseEvent.BUTTON3) { mode = DragMode.ROTATE_VIEW; }


### PR DESCRIPTION
Fix apparent bug where the code has 
"if not shiftkey down, then rotate-view"
"if shiftkey down, then also, rotate-view" ... 
then later, there's a case statement for "TRANSLATE_VIEW", which isn't referenced anywhere else, ever.

changing this enables an otherwise non-existent "pan" mode in the UI.
